### PR TITLE
Add support for Appium & ADB CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # react-native-launch-arguments
 
-React Native module to get launch arguments. Make passing parameters from testing tool to react native super easy. 
+React Native module to get launch arguments. Make passing parameters from testing tool to react native super easy.
 
-Mostly it's made for using 
+Mostly it's made for using
 * [`launchArgs parameter of device.launchApp method`](https://github.com/wix/Detox/blob/master/docs/APIRef.DeviceObjectAPI.md#7-additional-launch-arguments) of [Detox](https://github.com/wix/Detox/)
 * [`optionalIntentArguments (Android)` and `processArguments (iOS)`](http://appium.io/docs/en/writing-running-appium/caps/) parameters with [Appium](http://appium.io/)
 
 **iOS**: it takes data from `[[NSProcessInfo processInfo] arguments]`
 
-**Android**: it takes data from [`currentActivity.getIntent().getBundleExtra("launchArgs")`](https://developer.android.com/reference/android/content/Intent#getBundleExtra(java.lang.String)) together with [`currentActivity.getIntent().getStringExtra("launchArgs")`](https://developer.android.com/reference/android/content/Intent#getStringExtra(java.lang.String))
-* see [`ADB docs`](https://developer.android.com/studio/command-line/adb#IntentSpec) for details
+**Android**: it takes data from `currentActivity.getIntent().getBundleExtra("launchArgs")` for detox and `intent.getExtras()` for ADB params
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-launch-arguments
 
-Make passing parameters from testing tool to react native super easy. 
+React Native module to get launch arguments. Make passing parameters from testing tool to react native super easy. 
 
 Mostly it's made for using 
 * [`launchArgs parameter of device.launchApp method`](https://github.com/wix/Detox/blob/master/docs/APIRef.DeviceObjectAPI.md#7-additional-launch-arguments) of [Detox](https://github.com/wix/Detox/)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # react-native-launch-arguments
 
-React Native module to get launch arguments.
+Make passing parameters from testing tool to react native super easy. 
 
-Mostly it's made for using [`launchArgs parameter of device.launchApp method`](https://github.com/wix/Detox/blob/master/docs/APIRef.DeviceObjectAPI.md#7-additional-launch-arguments) of [Detox](https://github.com/wix/Detox/)
+Mostly it's made for using 
+* [`launchArgs parameter of device.launchApp method`](https://github.com/wix/Detox/blob/master/docs/APIRef.DeviceObjectAPI.md#7-additional-launch-arguments) of [Detox](https://github.com/wix/Detox/)
+* [`optionalIntentArguments (Android)` and `processArguments (iOS)`](http://appium.io/docs/en/writing-running-appium/caps/) parameters with [Appium](http://appium.io/)
 
 **iOS**: it takes data from `[[NSProcessInfo processInfo] arguments]`
 
-**Android**: it takes data from `currentActivity.getIntent().getBundleExtra("launchArgs")`
+**Android**: it takes data from [`currentActivity.getIntent().getBundleExtra("launchArgs")`](https://developer.android.com/reference/android/content/Intent#getBundleExtra(java.lang.String)) together with [`currentActivity.getIntent().getStringExtra("launchArgs")`](https://developer.android.com/reference/android/content/Intent#getStringExtra(java.lang.String))
+* see [`ADB docs`](https://developer.android.com/studio/command-line/adb#IntentSpec) for details
 
 ## Getting started
 

--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -1,3 +1,4 @@
+
 package com.reactnativelauncharguments;
 
 import android.app.Activity;
@@ -30,29 +31,27 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
     }
 
     @Override
-    public Map < String, Object > getConstants() {
-        Map < String, Object > map = new HashMap();
+    public Map<String, Object> getConstants() {
+        Map<String, Object> map = new HashMap();
 
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
             if (intent != null) {
-                //parse all extras
+                Bundle bundle = intent.getBundleExtra("launchArgs");
+                if (bundle != null) {
+                    Set<String> ks = bundle.keySet();
+                    Iterator<String> iterator = ks.iterator();
+                    while (iterator.hasNext()) {
+                        String key = iterator.next();
+                        map.put(key, bundle.getString(key));
+                    }
+                }
+                //for CLI ADB params
                 Bundle bundleExtras = intent.getExtras();
                 if (bundleExtras != null) {
-                    for (String key: bundleExtras.keySet()) {
-                        //bundle inside bundle put by detox
-                        if ("launchArgs".equals(key)) {
-                            Bundle bundle = intent.getBundleExtra(key);
-                            if (bundle != null) {
-                                Set < String > ks = bundle.keySet();
-                                Iterator < String > iterator = ks.iterator();
-                                while (iterator.hasNext()) {
-                                    String innerkey = iterator.next();
-                                    map.put(innerkey, bundle.getString(innerkey));
-                                }
-                            }
-                        } else {
+                    for (String key : bundleExtras.keySet()) {
+                        if (!"launchArgs".equals(key)) {
                             map.put(key, bundleExtras.get(key));
                         }
                     }

--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -30,26 +30,31 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
     }
 
     @Override
-    public Map<String, Object> getConstants() {
-        Map<String, Object> map = new HashMap();
+    public Map < String, Object > getConstants() {
+        Map < String, Object > map = new HashMap();
 
         Activity activity = getCurrentActivity();
         if (activity != null) {
             Intent intent = activity.getIntent();
             if (intent != null) {
-                Bundle bundle = intent.getBundleExtra("launchArgs");
-                if (bundle != null) {
-                    Set<String> ks = bundle.keySet();
-                    Iterator<String> iterator = ks.iterator();
-                    while (iterator.hasNext()) {
-                        String key = iterator.next();
-                        map.put(key, bundle.getString(key));
-                    }
-
-                //ADB CLI can't pass bundle only "extras"
-                String strValue = intent.getStringExtra("launchArgs");
-                    if (strValue != null) {
-                            map.put("launchArgs", strValue);
+                //parse all extras
+                Bundle bundleExtras = intent.getExtras();
+                if (bundleExtras != null) {
+                    for (String key: bundleExtras.keySet()) {
+                        //bundle inside bundle put by detox
+                        if ("launchArgs".equals(key)) {
+                            Bundle bundle = intent.getBundleExtra(key);
+                            if (bundle != null) {
+                                Set < String > ks = bundle.keySet();
+                                Iterator < String > iterator = ks.iterator();
+                                while (iterator.hasNext()) {
+                                    String innerkey = iterator.next();
+                                    map.put(innerkey, bundle.getString(innerkey));
+                                }
+                            }
+                        } else {
+                            map.put(key, bundleExtras.get(key));
+                        }
                     }
                 }
             }

--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -45,6 +45,12 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
                         String key = iterator.next();
                         map.put(key, bundle.getString(key));
                     }
+
+                //ADB CLI can't pass bundle only "extras"
+                String strValue = intent.getStringExtra("launchArgs");
+                    if (strValue != null) {
+                            map.put("launchArgs", strValue);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added support for Appium too.
Appium (and ADB) puts single extra params to the Intent . It is unable to add an entire bundle extra param.
Added support for StringExtra parameter which can be added successfully. 