### PR TITLE
Put string in hashmap for intent extras that are not serialzable

### DIFF
--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -11,6 +11,8 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
+import java.io.Serializable;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -52,7 +54,11 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
                 if (bundleExtras != null) {
                     for (String key : bundleExtras.keySet()) {
                         if (!"launchArgs".equals(key)) {
-                            map.put(key, bundleExtras.get(key));
+                            if(!Serializable.class.isInstance(bundleExtras.get(key))) {
+                                map.put(key, bundleExtras.getString(key));
+                            } else {
+                                map.put(key, bundleExtras.get(key));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When an app supports deep linking, a URI intent extra is sent along to the
app (key is android.intent.extra.REFERRER). The error I got when trying to
put this particular extra in the hashmap was:
"Exception in HostObject::getpropName:LaunchArguments):
java.lang.IllegalArgumentException: Could not convert class
android.net.Uri$StringUri"
Checking whether the extra is serializable first, and calling "getString" instead
of "get" if this is the case, solves this crash.