### PR TITLE
Use maven-publish instead of maven to support React Native 0.67.1 (gradle 7)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,18 +10,6 @@
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 18
-def DEFAULT_TARGET_SDK_VERSION = 28
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
-
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
     // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -38,8 +26,19 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
+plugins {
+    id('com.android.library')
+    id('maven-publish')
+}
+
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
+def DEFAULT_MIN_SDK_VERSION = 18
+def DEFAULT_TARGET_SDK_VERSION = 28
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -72,7 +71,7 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'  // From node_modules
+    implementation 'com.facebook.react:react-native:+'
 }
 
 def configureReactNativePom(def pom) {
@@ -89,7 +88,7 @@ def configureReactNativePom(def pom) {
         licenses {
             license {
                 name packageJson.license
-                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                url packageJson.repository.baseUrl  '/blob/master/'  packageJson.licenseFilename
                 distribution 'repo'
             }
         }
@@ -108,8 +107,8 @@ afterEvaluate { project ->
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
-        classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        classpath = files(android.bootClasspath)
+        classpath = files(project.getConfigurations().getByName('compile').asList())
         include '**/*.java'
     }
 
@@ -119,7 +118,7 @@ afterEvaluate { project ->
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
         include '**/*.java'
     }
@@ -138,12 +137,11 @@ afterEvaluate { project ->
         archives androidJavadocJar
     }
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-            configureReactNativePom pom
-        }
-    }
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact androidSourcesJar
+            }
+         }
+     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+' // From node_modules
 }
 
 def configureReactNativePom(def pom) {
@@ -88,7 +88,7 @@ def configureReactNativePom(def pom) {
         licenses {
             license {
                 name packageJson.license
-                url packageJson.repository.baseUrl  '/blob/master/'  packageJson.licenseFilename
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
                 distribution 'repo'
             }
         }
@@ -107,8 +107,8 @@ afterEvaluate { project ->
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
-        classpath = files(android.bootClasspath)
-        classpath = files(project.getConfigurations().getByName('compile').asList())
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
         include '**/*.java'
     }
 


### PR DESCRIPTION
Maven has been deprecated since gradle 6.0 and was removed in gradle 7.0.

React Native 0.67.1 requires gradle 7.2.0.

This PR updates the library to use maven-publish which works with gradle 7.2.0 and React Native 0.67.1

Resolves #18