### PR TITLE
Less strict peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.8.1",
+    "react": ">16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This will adjust peerDependencies to prevent 

```
npm ERR! node_modules/react
npm ERR!   react@"17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.1" from react-native-launch-arguments@3.0.0
npm ERR! node_modules/react-native-launch-arguments
npm ERR!   react-native-launch-arguments@"^3.0.0" from the root project
```