### PR TITLE
Less strict dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.8.1",
+    "react": ">=16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
I created this PR to merge this needed change, as the other PR (https://github.com/iamolegga/react-native-launch-arguments/pull/25) seems stuck for now.