### PR TITLE
Remove gradle javadoc task

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,19 +105,6 @@ def configureReactNativePom(def pom) {
 afterEvaluate { project ->
     // some Gradle build hooks ref:
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
-    task androidJavadoc(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += files(android.bootClasspath)
-        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
-        classpath += files(project.getConfigurations().getByName('implementation').asList())
-        include '**/*.java'
-    }
-
-    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
-        from androidJavadoc.destinationDir
-    }
-
     task androidSourcesJar(type: Jar) {
         archiveClassifier = 'sources'
         from android.sourceSets.main.java.srcDirs
@@ -135,7 +122,6 @@ afterEvaluate { project ->
 
     artifacts {
         archives androidSourcesJar
-        archives androidJavadocJar
     }
 
     publishing {


### PR DESCRIPTION
There's not much use to the javadocs here, as the native sources don't contain additional docs and users of the package will interact with the JavaScript API only.

Resolves #38 

Thanks for maintaining the package 🙌 