### PR TITLE
Prevent crash when app is opened from universal link via RFID tag

### DIFF
--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -53,7 +53,7 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
                 Bundle bundleExtras = intent.getExtras();
                 if (bundleExtras != null) {
                     for (String key : bundleExtras.keySet()) {
-                        if (!"launchArgs".equals(key)) {
+                        if (!"launchArgs".equals(key) && !"android.nfc.extra.NDEF_MESSAGES".equals(key)) {
                             if(!Serializable.class.isInstance(bundleExtras.get(key))) {
                                 map.put(key, bundleExtras.getString(key));
                             } else {


### PR DESCRIPTION
When app is launched from an NDEF tag with a universal link the app crashes.

``` ERROR  Error: Exception in HostObject::get(propName:LaunchArguments): java.lang.IllegalArgumentException: Could not convert class android.nfc.NdefMessage
 ERROR  Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication). A frequent cause of the error is that the application entry file path is incorrect.
      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native.
```

I was able to isolate the issue within `com/reactnativelauncharguments/LaunchArgumentsModule.java:58`. I think the added class from the intents cannot be serialized and passed to react-native. 

This patch fixes this issue for us, but there might be a better solution

#67 