### PR TITLE
Wait for activity in native-module init (fix arg availability flakiness on Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 React Native module to get launch arguments. Make passing parameters from testing tool to react native super easy.
 
-Mostly it's made for using
-* [`launchArgs parameter of device.launchApp method`](https://wix.github.io/Detox/docs/api/device/#deviceapplaunchargs) of [Detox](https://github.com/wix/Detox/)
+Mostly it's made for using:
+* [`launchArgs parameter of device.launchApp method`](https://wix.github.io/Detox/docs/api/device/#7-launchargsadditional-process-launch-arguments) of [Detox](https://github.com/wix/Detox/) (see the [launch arguments guide](https://wix.github.io/Detox/docs/guide/launch-args) for full details)
 * [`optionalIntentArguments (Android)` and `processArguments (iOS)`](http://appium.io/docs/en/writing-running-appium/caps/) parameters with [Appium](http://appium.io/)
    ```tsx
    capabilities: {
@@ -53,6 +53,10 @@ interface MyExpectedArgs {
 }
 LaunchArguments.value<MyExpectedArgs>();
 ```
+
+## Caveats
+
+Due to React Native [issue #37518](https://github.com/facebook/react-native/issues/37518), on Android, the module force-waits for the Android activity to reach the [RESUMED state](https://developer.android.com/guide/components/activities/activity-lifecycle#alc), before moving foward with native-modules initialization completion. While commonly the wait is scarce (the activity is already in the resumed state at this point), until the RN issue is fixed, the module may introduce delays in app loading time in some edge cases.
 
 ## Verifying install
 

--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -1,29 +1,38 @@
-
 package com.reactnativelauncharguments;
 
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import androidx.annotation.NonNull;
-
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
 import java.io.Serializable;
-
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
-    private static ReactApplicationContext reactContext;
+
+    private static final long ACTIVITY_WAIT_INTERVAL = 100L;
+    private static final int ACTIVITY_WAIT_TRIES = 200;
+
+    private static final String DETOX_LAUNCH_ARGS_KEY = "launchArgs";
 
     LaunchArgumentsModule(ReactApplicationContext context) {
         super(context);
-        reactContext = context;
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+
+        // This is work-around for the RN problem described here:
+        // https://github.com/facebook/react-native/issues/37518
+        waitForActivity();
     }
 
     @NonNull
@@ -32,47 +41,14 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
         return "LaunchArguments";
     }
 
+    @Nullable
     @Override
     public Map<String, Object> getConstants() {
-        Map<String, Object> map = new HashMap();
-
-        Activity activity = getCurrentActivity();
-        if (activity != null) {
-            Intent intent = activity.getIntent();
-            if (intent != null) {
-                Bundle bundle = intent.getBundleExtra("launchArgs");
-                if (bundle != null) {
-                    Set<String> ks = bundle.keySet();
-                    Iterator<String> iterator = ks.iterator();
-                    while (iterator.hasNext()) {
-                        String key = iterator.next();
-                        map.put(key, bundle.getString(key));
-                    }
-                }
-                //for CLI ADB params
-                Bundle bundleExtras = intent.getExtras();
-                if (bundleExtras != null) {
-                    for (String key : bundleExtras.keySet()) {
-                        if (!"launchArgs".equals(key) && !"android.nfc.extra.NDEF_MESSAGES".equals(key)) {
-                            if(!Serializable.class.isInstance(bundleExtras.get(key))) {
-                                map.put(key, bundleExtras.getString(key));
-                            } else {
-                                map.put(key, bundleExtras.get(key));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        /**
-         * In iOS hashmap returns inside another one, because constants not
-         * visible. So, for consistency here do the same
-         */
-        Map<String, Object> consistentToIOSResult = new HashMap();
-        consistentToIOSResult.put("value", map);
-
-        return consistentToIOSResult;
+        return new HashMap<String, Object>() {{
+            // In iOS hashmap returns inside another one, because constants
+            // not visible. So, for consistency here do the same.
+            put("value", parseIntentExtras());
+        }};
     }
 
     /**
@@ -81,4 +57,65 @@ public class LaunchArgumentsModule extends ReactContextBaseJavaModule {
      */
     @ReactMethod
     public void foo() {}
+
+    private void waitForActivity() {
+        for (int tries = 0; tries < ACTIVITY_WAIT_TRIES && !isActivityReady(); tries++) {
+            sleep(ACTIVITY_WAIT_INTERVAL);
+        }
+    }
+
+    private Map<String, Object> parseIntentExtras() {
+        final Map<String, Object> map = new HashMap<>();
+
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return map;
+        }
+
+        final Intent intent = activity.getIntent();
+        if (intent == null) {
+            return map;
+        }
+
+        parseDetoxExtras(map, intent);
+        parseADBArgsExtras(map, intent);
+        return map;
+    }
+
+    private void parseDetoxExtras(Map<String, Object> map, Intent intent) {
+        final Bundle bundle = intent.getBundleExtra(DETOX_LAUNCH_ARGS_KEY);
+        if (bundle != null) {
+            for (String key : bundle.keySet()) {
+                map.put(key, bundle.getString(key));
+            }
+        }
+    }
+
+    private void parseADBArgsExtras(Map<String, Object> map, Intent intent) {
+        final Bundle bundleExtras = intent.getExtras();
+        if (bundleExtras != null) {
+            for (String key : bundleExtras.keySet()) {
+                if (!DETOX_LAUNCH_ARGS_KEY.equals(key) && !"android.nfc.extra.NDEF_MESSAGES".equals(key)) {
+
+                    if (!(bundleExtras.get(key) instanceof Serializable)) {
+                        map.put(key, bundleExtras.getString(key));
+                    } else {
+                        map.put(key, bundleExtras.get(key));
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isActivityReady() {
+        return getReactApplicationContext().hasCurrentActivity();
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsPackage.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsPackage.java
@@ -5,24 +5,19 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class LaunchArgumentsPackage implements ReactPackage {
-
+    
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
 
     @Override
-    public List<NativeModule> createNativeModules(
-            ReactApplicationContext reactContext) {
-        List<NativeModule> modules = new ArrayList<>();
-
-        modules.add(new LaunchArgumentsModule(reactContext));
-
-        return modules;
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        final NativeModule nativeModule = new LaunchArgumentsModule(reactContext);
+        return Collections.singletonList(nativeModule);
     }
 }


### PR DESCRIPTION
Styling improvements aside, this aims at fixing issue #44, by introducing a polling-based wait for the activity to be _ready_ (i.e. the equivalent of having it reach the _resumed_ state).

I've tried to work around the core react native issue in other ways, but it impossible to get passed react native and get a hold of the activity from within a native module.

As for the original suggestion - of switching to an `await`-based API (i.e. by providing a `@ReactMethod` inside the native-module): I decided not to go that way because using `async-await` where React components are defined as functions (rather than classes) is less trivial, requiring state management using `useEffect()` and so on; I strive to keep things as trivial as possible for the user.