### PR TITLE
fix(android): do not wait for activity when app is killed

### DIFF
--- a/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
+++ b/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java
@@ -1,6 +1,8 @@
 package com.reactnativelauncharguments;
 
 import android.app.Activity;
+import android.app.ActivityManager;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -10,6 +12,7 @@ import com.facebook.react.bridge.ReactMethod;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.NonNull;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,21 @@
-import { NativeModules } from "react-native";
+import { NativeModules, Platform } from "react-native";
+
+const LINKING_ERROR =
+  `The package 'react-native-launch-arguments' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: "" }) +
+  "- You rebuilt the app after installing the package\n" +
+  "- You are not using Expo managed workflow\n";
+
+const LaunchArgumentsModule = NativeModules.LaunchArguments
+  ? NativeModules.LaunchArguments
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    );
 
 type RawMap = Record<string, string>;
 
@@ -8,19 +25,27 @@ type LaunchArgumentsType = {
   value<T extends object = ParsedMap>(): T;
 };
 
-const raw = NativeModules.LaunchArguments.value as RawMap;
-const parsed: ParsedMap = {};
-for (const k in raw) {
-  const rawValue = raw[k];
-  try {
-    parsed[k] = JSON.parse(rawValue);
-  } catch {
-    parsed[k] = rawValue;
-  }
-}
+let parsed: ParsedMap | null = null;
 
 export const LaunchArguments: LaunchArgumentsType = {
   value<T>(): T {
-    return (parsed as any) as T;
+    if (parsed) {
+      return parsed as any as T;
+    }
+
+    parsed = {};
+
+    const raw = LaunchArgumentsModule.value as RawMap;
+
+    for (const k in raw) {
+      const rawValue = raw[k];
+      try {
+        parsed[k] = JSON.parse(rawValue);
+      } catch {
+        parsed[k] = rawValue;
+      }
+    }
+
+    return parsed as any as T;
   },
 };


### PR DESCRIPTION
## Why
We ran into an issue with push notifications where the background handler was taking too long to run until the timeout because the package was waiting for an activity to be available. Except there is no activity when the app is stopped.

We also want to have a way to include the package only on a special build of the app (by disabling auto-linking) and retrieve the launch arguments values ​​lazily.

## What
1️⃣ Update the LaunchArgumentsModule to only wait for an activity when the app is not stopped
2️⃣ Get the launch arguments lazily (when calling the `.value` getter) and throw only when a property is accessed (in our case when we try to read the launch arguments)
3️⃣ Add a linking error message (could close https://github.com/iamolegga/react-native-launch-arguments/issues/69)

## Todo
- [x] Test with different Android versions
- [x] Test with different E2E test tools (detox / appium / maestro)