### PR TITLE
fix: add support for non-dashed arguments for maestro

### DIFF
--- a/ios/LaunchArguments.m
+++ b/ios/LaunchArguments.m
@@ -71,6 +71,17 @@ RCT_EXPORT_MODULE()
 			argsdict[[self cleanValue:current]] = arguments[i+1];
 			i++;
 		}
+
+		// maestro bare words as keys
+		else {
+			NSString *next = (i + 1 < arguments.count) ? arguments[i+1] : nil;
+			if(!next || [self isKey:next]){
+				argsdict[current] = truthy;
+			} else {
+				argsdict[current] = next;
+				i++;
+			}
+		}
 	}
 
 	return [NSDictionary dictionaryWithDictionary:argsdict];


### PR DESCRIPTION
Currently, react-native-launch-arguments only recognizes arguments starting with `-` or `--`, and skips anything else as "unrecognized". This can be problematic for E2E tests or other use cases where we want to pass bare arguments, e.g. Maestro.